### PR TITLE
Add the {product_name} to the content of the mail

### DIFF
--- a/mails/themes/modern/core/order_customer_comment.html.twig
+++ b/mails/themes/modern/core/order_customer_comment.html.twig
@@ -126,6 +126,7 @@
                                       <tr>
                                         <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                                           <div style="font-family:Open sans, arial, sans-serif;font-size:14px;line-height:25px;text-align:left;color:#363A41;"><span style=" font-size:16px" class="label">{{ 'Customer:'|trans({}, 'Emails.Body', locale)|raw }}</span> {firstname} {lastname} ({email})</div>
+                                          <div style="font-family:Open sans, arial, sans-serif;font-size:14px;line-height:25px;text-align:left;color:#363A41;"><span style=" font-size:16px" class="label">{{ 'Product:'|trans({}, 'Emails.Body', locale)|raw }}</span> {product_name}</div>
                                         </td>
                                       </tr>
                                     </tbody>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Add the {product_name} to the content of the mail, it's already loaded by the controller but missing in the mail
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | yes
| Deprecations?     | yes
| Fixed ticket?     | Fixes #27581.
| How to test?      | Send a mail from an order detail in front-end, check the message received by the admin
| Possible impacts? | 
