### PR TITLE
Give access to the txt and html files

### DIFF
--- a/mails/.htaccess
+++ b/mails/.htaccess
@@ -2,9 +2,15 @@
 <IfModule !mod_authz_core.c>
     Order deny,allow
     Deny from all
+    <Files ~ "(?i)^.*\.(txt|html)$">
+        Allow from all
+    </Files>
 </IfModule>
 
 # Apache 2.4
 <IfModule mod_authz_core.c>
     Require all denied
+    <Files ~ "(?i)^.*\.(txt|html)$">
+        Require all granted
+    </Files>
 </IfModule>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | From the order status form in admin, when a mail template is linked to an order state, it's not possible to preview the mail by clicking the button, due to a restricted access on the files
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | Edit an order status which is sending an email, and try to click on the Preview button to see the mail template
| Possible impacts? | 